### PR TITLE
Allow ProductionEndpoint to be configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	ProductionEndpoint = "https://app.files.com"
 	UserAgent          = "Files.com Go SDK"
 )
 
+var ProductionEndpoint string = "https://app.files.com"
 var APIKey string
 
 type HttpClient interface {


### PR DESCRIPTION
* Production endpoint variable should be configurable to allow usage of mock/testing servers.