### PR TITLE
Switch from module lpar/date to lpar/calendar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/lpar/date v1.0.0
+	github.com/lpar/calendar v0.2.0
 	github.com/panjf2000/ants/v2 v2.9.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/samber/lo v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZY
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/lpar/date v1.0.0 h1:bq/zVqFTUmsxvd/CylidY4Udqpr9BOFrParoP6p0x/I=
-github.com/lpar/date v1.0.0/go.mod h1:KjYe0dDyMQTgpqcUz4LEIeM5VZwhggjVx/V2dtc8NSo=
+github.com/lpar/calendar v0.2.0 h1:A1kxv6sbvBHFUkd2XotanIRqEXQGreQOeuGhkJqIaRA=
+github.com/lpar/calendar v0.2.0/go.mod h1:fsVJa4o2NvXYzaCE5RXMadqbZzWEhNCGOUPVHTIZdjc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/usagedailysnapshot.go
+++ b/usagedailysnapshot.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 
 	lib "github.com/Files-com/files-sdk-go/v3/lib"
-	"github.com/lpar/date"
+	"github.com/lpar/calendar"
 )
 
 type UsageDailySnapshot struct {
 	Id                           int64                  `json:"id,omitempty" path:"id,omitempty" url:"id,omitempty"`
-	Date                         *date.Date             `json:"date,omitempty" path:"date,omitempty" url:"date,omitempty"`
+	Date                         *calendar.Date         `json:"date,omitempty" path:"date,omitempty" url:"date,omitempty"`
 	ApiUsageAvailable            *bool                  `json:"api_usage_available,omitempty" path:"api_usage_available,omitempty" url:"api_usage_available,omitempty"`
 	ReadApiUsage                 int64                  `json:"read_api_usage,omitempty" path:"read_api_usage,omitempty" url:"read_api_usage,omitempty"`
 	WriteApiUsage                int64                  `json:"write_api_usage,omitempty" path:"write_api_usage,omitempty" url:"write_api_usage,omitempty"`


### PR DESCRIPTION
Module lpar/date is deprecated and recommends using lpar/calendar