### PR TITLE
fix: BuildPath drops string placeholder values, sending requests to the wrong URL

### DIFF
--- a/lib/query.go
+++ b/lib/query.go
@@ -46,6 +46,8 @@ func BuildPath(resourcePath string, values interface{}) (string, error) {
 		var exists bool
 		if m, ok := values.(map[string]interface{}); ok {
 			value, exists = m[placeholder]
+		} else if m, ok := values.(map[string]string); ok {
+			value, exists = m[placeholder]
 		} else if pathValue, err := findTag(values, "path", placeholder); err == nil {
 			exists = true
 			value = pathValue
@@ -74,6 +76,8 @@ func BuildPath(resourcePath string, values interface{}) (string, error) {
 				if err != nil {
 					return "", err
 				}
+			} else {
+				stringValue = url.PathEscape(v)
 			}
 		default:
 			stringValue = fmt.Sprintf("%v", v)

--- a/lib/query_test.go
+++ b/lib/query_test.go
@@ -106,6 +106,27 @@ func TestBuildPath(t *testing.T) {
 				"root/{path}",
 				map[string]interface{}{"path": "a/my-path"}},
 		},
+		{
+			name: "given a map of strings",
+			want: "root/a/my-path",
+			args: args{
+				"root/{path}",
+				map[string]string{"path": "a/my-path"}},
+		},
+		{
+			name: "given a map of strings with escaping",
+			want: "root/a%20file%20name.text",
+			args: args{
+				"root/{path}",
+				map[string]string{"path": "a file name.text"}},
+		},
+		{
+			name: "non-path string placeholder",
+			want: "users/bob%20smith",
+			args: args{
+				"users/{name}",
+				map[string]interface{}{"name": "bob smith"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
BuildPath only recognized `map[string]interface{}`, so the `map[string]string` that `file.Get` passes failed the type assertion and the `{path}` placeholder was silently replaced with an empty string. Every `file.Get(path)` requested `GET /files/` (the root) regardless of the argument.

The value-conversion switch also only assigned string values for the literal `path` placeholder, so any other string-valued placeholder was blanked. `chat_session.Find(ChatSessionFindParams{Id: "abc123"})` sends `GET /chat_sessions/` instead of `/chat_sessions/abc123`.

Added BuildPath tests for both; they fail without the fix.

🤖 Generated by Quad tha God