### PR TITLE
fix: IterChan.Next returns true on error events without storing a new value

### DIFF
--- a/lib/iterchan.go
+++ b/lib/iterchan.go
@@ -23,16 +23,20 @@ func (i *IterChan[T]) Init(ctx context.Context) *IterChan[T] {
 }
 
 func (i *IterChan[T]) Next() bool {
-	select {
-	case current := <-i.Send:
-		i.current.Store(current)
-	case err := <-i.SendError:
-		i.Error.Store(err)
-	case <-i.Done():
-		return false
+	for {
+		select {
+		case current := <-i.Send:
+			i.current.Store(current)
+			return true
+		case err := <-i.SendError:
+			// An error is not an iteration result: without a new value stored,
+			// Resource() would return nil or repeat the previous value. Record
+			// it for Err() and keep waiting for the next value or Done.
+			i.Error.Store(err)
+		case <-i.Done():
+			return false
+		}
 	}
-
-	return true
 }
 
 func (i *IterChan[T]) Current() interface{} {

--- a/lib/iterchan_test.go
+++ b/lib/iterchan_test.go
@@ -1,0 +1,64 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterChan_ErrorBeforeFirstValue(t *testing.T) {
+	it := (&IterChan[int]{}).Init(context.Background())
+	sendErr := errors.New("stat failed")
+
+	go func() {
+		it.SendError <- sendErr
+		it.Send <- 1
+		it.Stop()
+	}()
+
+	var values []int
+	for it.Next() {
+		values = append(values, it.Resource())
+	}
+
+	assert.Equal(t, []int{1}, values)
+	assert.Equal(t, sendErr, it.Err())
+}
+
+func TestIterChan_ErrorBetweenValues(t *testing.T) {
+	it := (&IterChan[int]{}).Init(context.Background())
+	sendErr := errors.New("stat failed")
+
+	go func() {
+		it.Send <- 1
+		it.SendError <- sendErr
+		it.Send <- 2
+		it.Stop()
+	}()
+
+	var values []int
+	for it.Next() {
+		values = append(values, it.Resource())
+	}
+
+	assert.Equal(t, []int{1, 2}, values)
+	assert.Equal(t, sendErr, it.Err())
+}
+
+func TestIterChan_ErrorOnly(t *testing.T) {
+	it := (&IterChan[int]{}).Init(context.Background())
+	sendErr := errors.New("stat failed")
+
+	go func() {
+		it.SendError <- sendErr
+		it.Stop()
+	}()
+
+	for it.Next() {
+		t.Fatalf("Next returned true with no value sent")
+	}
+
+	assert.Equal(t, sendErr, it.Err())
+}


### PR DESCRIPTION
When a walk worker sends on `SendError`, `Next()` stored the error and returned true without storing a new current value. Consumers call `Resource()` on every iteration (file/uploader.go:176, file/downloader.go:127), so an error event either panics on the nil interface conversion (error before the first file, e.g. a file deleted between ReadDir and stat) or silently processes the previous entry twice.

`Next()` now records the error for `Err()` and keeps waiting for the next value or Done, which is the contract consumers already assume (they check `it.Err()` after the loop). The walker cancels the iterator context on exit (`defer it.Stop()`), so skipping error events can't hang the loop.

🤖 Generated by Quad tha God