### PR TITLE
fix: Iter.Reload returns an already-consumed iterator and drops list params

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -188,7 +188,11 @@ func (i *Iter) NextPage() bool {
 // Reload ignores any id passed in and creates a new reset Iter
 func (i *Iter) Reload(opts ...RequestResponseOption) IterI {
 	newIter := *i
-	newIter.ListParams = &ListParams{}
+	newIter.Values = nil
+	newIter.CurrentIndex = 0
+	newIter.Page = 0
+	newIter.Error = nil
 	newIter.requestResponseOptions = opts
+	newIter.SetCursor("")
 	return &newIter
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -72,6 +72,38 @@ func TestIter_Next_PerPage_of_one(t *testing.T) {
 	assert.Equal(1, recordCount)
 }
 
+func TestIter_Reload(t *testing.T) {
+	assert := assert.New(t)
+	params := ListParams{PerPage: 2}
+	it := Iter{}
+	it.ListParams = &params
+
+	it.Query = func(values lib.Values, _ ...RequestResponseOption) (*[]interface{}, string, error) {
+		urlValues, err := values.ToValues()
+		assert.NoError(err)
+		if urlValues.Get("cursor") == "" {
+			ret := make([]interface{}, 2)
+			return &ret, "next-cursor", nil
+		}
+		ret := make([]interface{}, 2)
+		return &ret, "", nil
+	}
+
+	recordCount := 0
+	for it.Next() {
+		recordCount += 1
+	}
+	assert.Equal(4, recordCount)
+
+	reloaded := it.Reload()
+	reloadCount := 0
+	for reloaded.Next() {
+		reloadCount += 1
+	}
+	assert.Equal(4, reloadCount, "a reloaded iterator should iterate the full result set again")
+	assert.Equal(int64(2), reloaded.(*Iter).GetParams().PerPage, "Reload should preserve the original list params")
+}
+
 func TestIter_Next_No_Cursor(t *testing.T) {
 	assert := assert.New(t)
 	params := ListParams{}


### PR DESCRIPTION
`Reload` copied the consumed iterator (Values, CurrentIndex, Page, Cursor) and replaced ListParams with a bare `&ListParams{}`. A fully-iterated list reloads to zero items, since `GetPage` bails when Values is set and Cursor is empty, and PerPage plus every typed filter param was dropped. Every generated resource client wraps this method verbatim.

`Reload` now resets the iteration state and keeps the original params, so it re-lists from page one with the same filters.

🤖 Generated by Quad tha God