### PR TITLE
fix: fsmount data loss, deadlock, and locking bugs

### DIFF
--- a/fsmount/internal/flags/flags.go
+++ b/fsmount/internal/flags/flags.go
@@ -26,9 +26,14 @@ func (f FuseFlags) IsEventOnly() bool {
 	return int(f)&O_EVTONLY != 0
 }
 
-// IsReadOnly checks if the flag is set to read-only.
+// IsReadOnly reports whether the flags carry no write intent: the POSIX
+// access mode (low two bits: O_RDONLY=0, O_WRONLY=1, O_RDWR=2) is O_RDONLY
+// and no bit implying modification (O_CREAT, O_TRUNC, O_APPEND) is set.
+// Kernels set unrelated bits on read opens (e.g. Linux forces
+// O_LARGEFILE=0x8000 from 64-bit userspace), so the full flag word must not
+// be compared against zero.
 func (f FuseFlags) IsReadOnly() bool {
-	return int(f) == 0
+	return int(f)&0x3 == 0 && !f.IsCreate() && !f.IsTruncate() && !f.IsAppend()
 }
 
 // IsWriteOnly checks if the flag is set to write-only.

--- a/fsmount/internal/flags/flags_test.go
+++ b/fsmount/internal/flags/flags_test.go
@@ -75,6 +75,19 @@ func TestFuseFlags(t *testing.T) {
 			expectedString:          "FuseFlags{O_CREAT|O_EXCL}",
 		},
 		{
+			name:                    "ReadOnlyWithKernelSetBits",
+			flags:                   fuse.O_RDONLY | 0x8000, // Linux forces O_LARGEFILE (0x8000) on every 64-bit open
+			expectedReadOnly:        true,
+			expectedWriteOnly:       false,
+			expectedReadWrite:       false,
+			expectedCreate:          false,
+			expectedExclusive:       false,
+			expectedTruncate:        false,
+			expectedAppend:          false,
+			expectedCreateExclusive: false,
+			expectedString:          "FuseFlags{O_EVTONLY|O_RDONLY}",
+		},
+		{
 			name:                    "TruncateAppend",
 			flags:                   fuse.O_TRUNC | fuse.O_APPEND,
 			expectedReadOnly:        false,

--- a/fsmount/localfs_linux.go
+++ b/fsmount/localfs_linux.go
@@ -14,7 +14,7 @@ import (
 func (fs *LocalFs) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc int) {
 	fq := fs.fqPath(path)
 	stgo := syscall.Stat_t{}
-	if err := syscall.Lstat(path, &stgo); err != nil {
+	if err := syscall.Lstat(fq, &stgo); err != nil {
 		if !os.IsNotExist(err) {
 			fs.log.Trace("LocalFs: Getattr: failed to lstat file: path=%v, fh=%v, err=%v", fq, fh, err)
 			return -fuse.EIO

--- a/fsmount/localfs_windows.go
+++ b/fsmount/localfs_windows.go
@@ -28,7 +28,13 @@ func (fs *LocalFs) Getattr(path string, stat *fuse.Stat_t, fh uint64) (errc int)
 		return -fuse.ENOENT
 	}
 
-	stat.Mode = uint32(info.Mode())
+	// Go's FileMode encodes directories in its own high bits; FUSE consumers
+	// dispatch on the POSIX S_IFMT bits, so translate explicitly.
+	if info.IsDir() {
+		stat.Mode = fuse.S_IFDIR | 0755
+	} else {
+		stat.Mode = fuse.S_IFREG | uint32(info.Mode().Perm())
+	}
 	stat.Size = int64(info.Size())
 	node, ok := fs.vfs.fetch(path)
 	if ok && node.info.uid != 0 {

--- a/fsmount/open_handles.go
+++ b/fsmount/open_handles.go
@@ -211,6 +211,13 @@ func (h *OpenHandles) startUploadSweeper() {
 					continue
 				}
 				_, bytesWritten, lastActivity := node.uploadStats()
+				if lastActivity.IsZero() {
+					// A write session exists but its upload has not started
+					// (uploads begin at flush/release). Treating the zero
+					// timestamp as idle time would cancel the live session
+					// and delete its working copy on the first sweep.
+					continue
+				}
 				idle := time.Since(lastActivity)
 				h.log.Debug("Upload sweeper: checking upload for path %s, bytes written: %d, last activity: %v, idle time: %v", node.path, bytesWritten, lastActivity, idle)
 				// Case A: upload opened but never wrote any bytes — allow a long grace period.

--- a/fsmount/remotefs.go
+++ b/fsmount/remotefs.go
@@ -372,10 +372,16 @@ func (fs *RemoteFs) Init() {
 func (fs *RemoteFs) Destroy() {
 	fs.log.Debug("RemoteFs: Destroy: removing all file locks")
 
+	// Snapshot under the mutex, then release it: unlock re-acquires
+	// lockMapMutex, so unlocking while holding it self-deadlocks.
 	fs.lockMapMutex.Lock()
-	defer fs.lockMapMutex.Unlock()
-	for path, lockInfo := range fs.lockMap {
-		fs.unlock(path, lockInfo.Fh)
+	locks := make(map[string]*lockInfo, len(fs.lockMap))
+	for path, li := range fs.lockMap {
+		locks[path] = li
+	}
+	fs.lockMapMutex.Unlock()
+	for path, li := range locks {
+		fs.unlock(path, li.Fh)
 	}
 
 	fs.log.Debug("RemoteFs: Destroy: stopping cache maintenance")
@@ -2621,7 +2627,10 @@ func (fs *RemoteFs) listDir(path string) (childPaths map[string]struct{}, opErr 
 			childPath := path_lib.Join(path, path_lib.Base(lock.Path))
 
 			// Ignore paths where the lock is held by this file system.
-			if _, ok := fs.lockMap[childPath]; ok {
+			fs.lockMapMutex.Lock()
+			_, heldByUs := fs.lockMap[childPath]
+			fs.lockMapMutex.Unlock()
+			if heldByUs {
 				continue
 			}
 


### PR DESCRIPTION
Fixes from an audit of the fsmount package, one commit each:

- The upload sweeper computed idle time from a zero timestamp for write sessions whose upload hasn't started yet (uploads begin at flush/release), so `time.Since(zero)` exceeded every timeout and the sweeper cancelled live sessions, deleting their working copies, on its first 10-minute tick. Silent data loss for any file held open for write across a tick.
- `flags.IsReadOnly` compared the whole flag word to zero. Linux forces O_LARGEFILE (0x8000) into every open from 64-bit userspace, so all read opens were classified as writes: reading a file without the `w` permission returned EACCES, and every read open acquired an exclusive remote lock. It now masks the POSIX access mode plus write-implying bits (O_CREAT, O_TRUNC, O_APPEND).
- `RemoteFs.Destroy` held `lockMapMutex` while calling `unlock`, which re-acquires the same mutex. Unmounting with any held file lock deadlocked. It now snapshots the map before unlocking.
- `listDir` read `lockMap` without the mutex, racing lock acquisition on another FUSE dispatch thread (fatal concurrent map read and write).
- Linux `LocalFs.Getattr` lstat'd the raw FUSE path instead of the sandbox path (`fq` was computed but only logged), so locally-stored files always returned ENOENT. The darwin twin already used `fq`.
- Windows `LocalFs.Getattr` emitted Go FileMode bits instead of POSIX S_IFMT, so locally-stored directories were reported with `S_IFMT == 0` and Explorer treated them as zero-type files.

This package needs fuse.h to compile, which my machine doesn't have, so verification here was `GOOS=windows go build`/`go vet` (clean) plus a new IsReadOnly test case that needs CI to execute.

🤖 Generated by Quad tha God